### PR TITLE
Revert "Removed the `load_dotenv` package / Refactoring"

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # if your configuration for server/port is different than the defaults, edit them accordingly
-plex_server=localhost
-plex_port=32400
+server=localhost
+port=32400
 # Replace 'YOUR_TOKEN_HERE' with your X-Plex-Token string obtained from your server.
 plex_token=YOUR_TOKEN_HERE

--- a/README.md
+++ b/README.md
@@ -5,16 +5,14 @@ Display current Plex sessions in Ubuntu MOTD output
 
 - **You will need Python 3.5 or later** - it may (probably will) work with Python 3 or later, but I haven't tested it.
 
-- [Export](https://help.ubuntu.com/community/EnvironmentVariables#A.2Fetc.2Fenvironment) the following environment variables by adding them to the `/etc/environment` file
-```bash
-# if your configuration for server/port is different than the defaults, edit them accordingly
-plex_server=localhost
-plex_port=32400
-# Replace 'YOUR_TOKEN_HERE' with your X-Plex-Token string obtained from your server.
-plex_token=YOUR_TOKEN_HERE
-```
+- Run `pip3 install -r requirements.txt` to install the required Python packages.
+
+- Edit `server` and `port` in the `.env` file if they are different than the defaults.
+
+- Replace `YOUR_TOKEN_HERE` with your X-Plex-Token string obtained from your server.
 
 - Once you have edited the script and confirmed it is working, copy it to `/etc/update-motd.d/` with an appropriate name - (`95-plex` is recommended)
 
+- Move the `.env` file in the `/etc/update-motd.d/` directory.
 
 ![alt text](https://raw.githubusercontent.com/mveinot/plex-motd/master/README/1.png)

--- a/plex-motd.py
+++ b/plex-motd.py
@@ -4,11 +4,15 @@ from re import search
 from urllib import request, error
 from xml.etree.ElementTree import XML
 
-# if your configuration for server/port is different from the defaults, edit them accordingly in the env variables
-server = str(getenv('plex_server'))
-port = str(getenv('plex_port'))
-plex_token = str(getenv('plex_token'))
+from dotenv import load_dotenv
 
+# loads the environment variables from the .env file
+load_dotenv()
+
+# if your configuration for server/port is different from the defaults, edit them accordingly in the .env file
+server = str(getenv('server'))
+port = str(getenv('port'))
+plex_token = str(getenv('plex_token'))
 # ----------------COLORS-----------------
 white = '\033[1;37m'
 yellow = '\u001b[38;5;214m'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-dotenv~=0.19.0


### PR DESCRIPTION
This works when calling the script manually, but when expecting the server to run it automatically, the update-motd system breaks.

This is because pam_motd generates the motd output with code like the following:

`if (!system("/usr/bin/env -i PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin run-parts --lsbsysinit /etc/update-motd.d > /run/motd.dynamic.new"))
rename("/run/motd.dynamic.new", "/run/motd.dynamic");
`

The `env -i` part means ignore any existing environment variables and start clean.

This will need to be reworked